### PR TITLE
Task 1: fix the project name shown on the applicant index page

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -11,8 +11,4 @@ class Applicant < ApplicationRecord
   belongs_to :project
 
   enum status: { applied: 0, initial_review: 1, more_information_required: 2, declined: 3, approved: 4 }
-
-  def project_title
-    'Project'
-  end
 end

--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -19,7 +19,7 @@
   <% @applicants.each do |applicant| %>
     <tr>
       <td><%= applicant.name %></td>
-      <td><%= applicant.project_title %></td>
+      <td><%= applicant.project.title %></td>
       <td><%= applicant.status.titleize %></td>
       <td><%= link_to "Show this applicant", applicant %></td>
     </tr>

--- a/spec/views/applicants/index.html.erb_spec.rb
+++ b/spec/views/applicants/index.html.erb_spec.rb
@@ -10,10 +10,18 @@ RSpec.describe 'applicants/index' do
     )
   end
 
-  let(:project) do
+  let(:project1) do
     Project.create!(
       payment_date: Date.current + 1.month,
-      title: 'Project',
+      title: 'Project 1',
+      fund:
+    )
+  end
+
+  let(:project2) do
+    Project.create!(
+      payment_date: Date.current + 1.month,
+      title: 'Project 2',
       fund:
     )
   end
@@ -24,14 +32,14 @@ RSpec.describe 'applicants/index' do
                name: 'Applicant 1',
                overview: 'Overview',
                funding: 500,
-               project:,
+               project: project1,
                status: 0
              ),
              Applicant.create!(
                name: 'Applicant 2',
                overview: 'Overview',
                funding: 500,
-               project:,
+               project: project2,
                status: 4
              )
            ])
@@ -41,7 +49,8 @@ RSpec.describe 'applicants/index' do
     render
     cell_selector = 'tr>td'
     assert_select cell_selector, text: Regexp.new('Applicant'), count: 2
-    assert_select cell_selector, text: 'Project', count: 2
+    assert_select cell_selector, text: 'Project 1', count: 1
+    assert_select cell_selector, text: 'Project 2', count: 1
     assert_select cell_selector, text: 'Applied', count: 1
     assert_select cell_selector, text: 'Approved', count: 1
   end


### PR DESCRIPTION
**Task 1:**  There was a bug in the Applicants index page, the Project title was the same for every Applicant, and this was asked to fix it. 

> There is a bug in the Applicants index page, the Project title is the same for every Applicant, and this needs to be fixed. Once this is fixed, we are interested to know your thoughts on how this bug could have been avoided?

- [X] The problem is fixed
- [X]  Write thoughts on how this bug could have been avoided
  - To avoid the problem, we could have tested extensively the different applicants and the names of the projects expected to be shown on the index page (_used TDD to see the failed specs and then make them pass_).


<img width="626" alt="Screen Shot 2022-12-05 at 19 29 01" src="https://user-images.githubusercontent.com/7799840/205756632-ef5366f9-ffcc-4876-b69c-52375b442a32.png">
