### PR TITLE
Task 3: improves Payments page load performance

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -2,5 +2,7 @@
 
 # Controller for upcoming Payments
 class PaymentsController < ApplicationController
-  def index; end
+  def index
+    @projects = Project.order(:payment_date).where('payment_date >= :date', date: Date.current).includes(:applicants)
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,4 +6,5 @@ class Project < ApplicationRecord
   validates :payment_date, presence: true
 
   belongs_to :fund
+  has_many :applicants, dependent: :nullify
 end

--- a/app/views/payments/index.html.erb
+++ b/app/views/payments/index.html.erb
@@ -1,13 +1,4 @@
 <h1>Payments</h1>
-
-<%
-  projects = Project.all
-
-  dates = projects.each_with_object(Hash.new { |k, v| k[v] = [] }) do |project, output|
-    output[project.payment_date] << project.title
-  end
-%>
-
 <table id="payments">
   <thead>
     <tr>
@@ -17,21 +8,13 @@
     </tr>
   </thead>
   <tbody>
-  <%
-    dates.sort_by { |date, _project| date }
-         .select { |date, _project| date >= Date.current }
-         .to_h
-         .keys
-         .each do |date|
-  %>
-    <% dates[date].each do |project| %>
+    <% @projects.each do |project| %>
       <tr>
-        <td><%= date %></td>
-        <td><%= project %></td>
+        <td><%= project.payment_date %></td>
+        <td><%= project.title %></td>
         <td>
           <%=
-            project = Project.find_by(title: project)
-            applicants = Applicant.all.select do |applicant|
+            applicants = project.applicants.select do |applicant|
               if applicant.project.title == project.title &&
                  applicant.status == 'approved'
                 true
@@ -45,6 +28,5 @@
         </td>
       </tr>
     <% end %>
-  <% end %>
   </tbody>
 </table>

--- a/spec/views/payments/index.html.erb_spec.rb
+++ b/spec/views/payments/index.html.erb_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'payments/index.html.erb' do
       status: 4
     )
 
-    project2
+    assign(:projects, [project, project2])
   end
 
   it 'renders a list of payments' do


### PR DESCRIPTION
**Task 3:** Loading the Payments Index page was taking too long. They requested to improve the page load performance.

> The Operations team need the Payments page to be more performant as they are receiving 504 timeouts when accessing this in our production environment sometimes. Please describe where you think the issue(s) lie and provide your thoughts on how they might be resolved. If time permits, implement your solution (or implement just enough to prove your ideas).
The two main problems that I identified were:

**The main problems that I identified:**
We had a complexity of `O(n^3)` when looping the through `dates`, we were doing more logic and queries than we really needed (_note: not a good ideia to have controller logic in the view section_)

**The payments list has two main logic:**

- We want to show only `projects` where `payment_date` is in the future (`>= Date.current`)
- Order the dates by `:payment_date`

**To fix the problem, I followed the next approach:**

- Added the project `has_many` association with the `applicant`
- We are loading all `projects` on `payments_controller`, and to avoid problems like the N+1 problem, I include the applicants' relation to the same query (_now we have all information needed to show the payments page information_)

**Note:**
- I would add pagination to improve performance
- I would create capybara specs for the payments index page